### PR TITLE
ツイート詳細表示機能実装

### DIFF
--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -1,4 +1,6 @@
 class TweetsController < ApplicationController
+  before_action :set_tweet, only:[:edit, :show]
+
   def index
     @tweets = Tweet.all
   end
@@ -17,7 +19,6 @@ class TweetsController < ApplicationController
   end
 
   def edit
-    @tweet = Tweet.find(params[:id])
   end
   
   def update
@@ -26,12 +27,15 @@ class TweetsController < ApplicationController
   end
 
   def show
-    @tweet = Tweet.find(params[:id])
   end
 
   private
   def tweet_params
     params.require(:tweet).permit(:name, :image, :text)
+  end
+
+  def set_tweet
+    @tweet = Tweet.find(params[:id])
   end
 
 end

--- a/app/controllers/tweets_controller.rb
+++ b/app/controllers/tweets_controller.rb
@@ -24,7 +24,11 @@ class TweetsController < ApplicationController
     tweet = Tweet.find(params[:id])
     tweet.update(tweet_params)
   end
-  
+
+  def show
+    @tweet = Tweet.find(params[:id])
+  end
+
   private
   def tweet_params
     params.require(:tweet).permit(:name, :image, :text)

--- a/app/views/tweets/index.html.erb
+++ b/app/views/tweets/index.html.erb
@@ -5,6 +5,8 @@
         <span><%= image_tag 'arrow_top.png' %></span>
         <ul class="more_list">
           <li>
+            <%= link_to '詳細', tweet_path(tweet.id), method: :get %>
+          <li>
             <%= link_to '編集', edit_tweet_path(tweet.id), method: :get %>
           </li>
           <li>

--- a/app/views/tweets/show.html.erb
+++ b/app/views/tweets/show.html.erb
@@ -1,0 +1,18 @@
+<div class="contents row">
+  <div class="content_post" style="background-image: url(<%= @tweet.image %>);">
+    <div class="more">
+      <span><%= image_tag 'arrow_top.png' %></span>
+      <ul class="more_list">
+        <li>
+          <%= link_to '編集', edit_tweet_path(@tweet.id), method: :get %>
+        </li>
+        <li>
+          <%= link_to '削除', tweet_path(@tweet.id), method: :delete %>
+        </li>
+      </ul>
+    </div>
+    <p><%= @tweet.text %></p>
+    <span class="name"><%= @tweet.name %>
+    </span>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root to: 'tweets#index'
-  resources :tweets, only: [:index, :new, :create, :destroy, :edit, :update]
+  resources :tweets
 end


### PR DESCRIPTION
# What
ツイートの詳細表示機能の実装
# Why
「詳細」ボタンを押すとツイートの詳細表示ページに遷移できる。詳細表示ページには該当するツイート1つだけが表示される。